### PR TITLE
Support remote deployment

### DIFF
--- a/minifilter/snFilter/install.cmd
+++ b/minifilter/snFilter/install.cmd
@@ -1,0 +1,8 @@
+echo Removing old version if exist > "%~dp0\install.log"
+start /wait /b sc stop snFilter >> "%~dp0\install.log" 2>&1
+start /wait /b sc delete snFilter >> "%~dp0\install.log" 2>&1
+start /wait /b pnputil -d %~dp0\snFilter.inf >> "%~dp0\install.log" 2>&1
+
+echo Installing new version >> "%~dp0\install.log" 2>&1
+start /wait /b pnputil -i -a %~dp0\snFilter.inf >> "%~dp0\install.log" 2>&1
+start /wait /b sc start snFilter >> "%~dp0\install.log" 2>&1

--- a/minifilter/snFilter/snFilter.vcxproj
+++ b/minifilter/snFilter/snFilter.vcxproj
@@ -30,6 +30,9 @@
     <RootNamespace>snFilter</RootNamespace>
     <ProjectName>snFilter</ProjectName>
     <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <RemoveDriver>False</RemoveDriver>
+    <InstallMode>CustomCommand</InstallMode>
+    <CommandLine>%SystemDrive%\DriverTest\Drivers\install.cmd</CommandLine>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -88,7 +91,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <DriverSign>
-      <FileDigestAlgorithm>SHA1</FileDigestAlgorithm>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
     </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -114,6 +117,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />
+    <FilesToPackage Include="install.cmd" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Communication.h" />
@@ -123,6 +127,9 @@
     <ClInclude Include="KernelCommon.h" />
     <ClInclude Include="KernelString.h" />
     <ClInclude Include="ShanonEntropy.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="install.cmd" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
This pull request provides needed changes to support remote deployment to target machine directly from Visual Studio like example on [this](https://learn.microsoft.com/en-us/windows-hardware/drivers/gettingstarted/writing-a-very-small-kmdf--driver#deploy-the-driver) guide.

Because this script uses `[DefaultInstall]` model in INF and does not register custom hardware ID deployment with `devcon.exe` whch Visual Studio uses by default does not works automatically so I solved it with custom script.

In additionally this PR will:
* ~Remove WDK version hardcoding and use latest one instead of.~
* Use SHA256 as hash algorithm on code signing certificate which removes needed for boot test machine "Disable Driver Signature Enforcement" option. (`bcdedit /set testsigning on` is still needed).

Tested with Visual Studio 2019 but should works on VS2022 too.